### PR TITLE
Fix nginx image tag to 1.24.0

### DIFF
--- a/chapter-06/deployment-rollingupdate.yaml
+++ b/chapter-06/deployment-rollingupdate.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.25.1
+        image: nginx:1.24.0
         ports:
         - containerPort: 80
         lifecycle:

--- a/chapter-06/deployment.yaml
+++ b/chapter-06/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.25.1
+        image: nginx:1.24.0
         ports:
         - containerPort: 80
 


### PR DESCRIPTION
ハンズオンの中で1.25.1に変更するようになっているので、変更後のマニフェストをコミットしていました。
ハンズオンでは最初1.24.0でマニフェストを実行するようになっているため、正しいタグに置き換えます。