### PR TITLE
Fix date-checker to run date command

### DIFF
--- a/chapter-06/job.yaml
+++ b/chapter-06/job.yaml
@@ -1,14 +1,14 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: date
+  name: date-checker
 spec:
   template:
     spec:
       containers:
       - name: date
         image: ubuntu:22.04
-        command: ["cur"]
+        command: ["date"]
       restartPolicy: Never
   backoffLimit: 4
 


### PR DESCRIPTION
おそらくハンズオンをやろうとしていたであろう、正しくないコマンドが実行されるマニフェストになっていました。
正しく動くように変更しました。また、Job名としてふさわしい名前に変更しました。